### PR TITLE
Changing from EDS to CDS

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,12 +3,12 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"flag"
+	//"flag"
 	"fmt"
 	"log"
 	"google.golang.org/grpc"
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
-	endpointservice "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
+	cluster_service "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 )
@@ -16,8 +16,8 @@ import (
 func main() {
 	// Take a resource flag to practice sending different resources.
 	// For simplicity, we will only request a single resource
-	resourceFlag := flag.String("resource", "foo", "a string")
-	flag.Parse()
+	//resourceFlag := flag.String("resource", "foo", "a string")
+	//flag.Parse()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -29,7 +29,7 @@ func main() {
 	}
 	log.Printf("Connected to xDS Server. State: %v", conn.GetState())
 
-	client := endpointservice.NewEndpointDiscoveryServiceClient(conn)
+	client := cluster_service.NewClusterDiscoveryServiceClient(conn)
 
 	// Discovery Request following format of go-control-plane integration test.
 	// we do not provide version_info to match the initial ACK diagram in
@@ -38,12 +38,14 @@ func main() {
 		Node: &envoy_config_core_v3.Node{
 			Id: "test-id",
 		},
-		TypeUrl:       resource.EndpointType,
-		ResourceNames: []string{*resourceFlag},
+		TypeUrl:       resource.ClusterType,
+		// Note that for CDS it is also possible to send a request w/o ResourceNames,
+		// and it will return all clusters (wildcard request)
+		ResourceNames: []string{"example_proxy_cluster"},
 	}
 
 	// Stream, send, and receive following integration test.
-	sclient, err := client.StreamEndpoints(ctx)
+	sclient, err := client.StreamClusters(ctx)
 	if err != nil {
 		log.Fatalf("err setting up stream: %v", err.Error())
 	}


### PR DESCRIPTION
The example go-control-plane server has a single cluster in its snapshot:
```
{Resources:[{Version:1 Items:map[]} {Version:1 Items:map[example_proxy_cluster:{Resource:name:"example_proxy_cluster"  type:LOGICAL_DNS  connect_timeout:{seconds:5}  load_assignment:{cluster_name:"example_proxy_cluster"  endpoints:{lb_endpoints:{endpoint:{address:{socket_address:{address:"www.envoyproxy.io"  port_value:80}}}}}}  dns_lookup_family:V4_ONLY Ttl:<nil>}]} {Version:1 Items:map[local_route:{Resource:name:"local_route"  virtual_hosts:{name:"local_service"  domains:"*"  routes:{match:{prefix:"/"}  route:{cluster:"example_proxy_cluster"  host_rewrite_literal:"www.envoyproxy.io"}}} Ttl:<nil>}]} {Version:1 Items:map[listener_0:{Resource:name:"listener_0"  address:{socket_address:{address:"0.0.0.0"  port_value:10000}}  filter_chains:{filters:{name:"envoy.filters.network.http_connection_manager"  typed_config:{[type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager]:{stat_prefix:"http"  rds:{config_source:{api_config_source:{api_type:GRPC  transport_api_version:V3  grpc_services:{envoy_grpc:{cluster_name:"xds_cluster"}}  set_node_on_first_message_only:true}  resource_api_version:V3}  route_config_name:"local_route"}  http_filters:{name:"envoy.filters.http.router"}}}}} Ttl:<nil>}]} {Version:1 Items:map[]} {Version:1 Items:map[]} {Version:1 Items:map[]}]}
```

To add an endpoint (EDS), you probably need to edit [resource.go](https://github.com/envoyproxy/go-control-plane/blob/dc8a2264016a391c80d146223b44bcc6ff77cd22/internal/example/resource.go#L167), and add your endpoints there, with their names.